### PR TITLE
Add select_option action for dcc.Dropdown support

### DIFF
--- a/dash_yada/yada.js
+++ b/dash_yada/yada.js
@@ -724,6 +724,23 @@ async function runScriptAction(step, target, originalTargetSpec) {
             }
         }
     }
+    if (step.action.toLowerCase() === 'select_option') {
+        console.log('SELECT_OPTION: starting');
+        var button = target;
+        console.log('SELECT_OPTION: target is', button);
+        button.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse'}));
+        button.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse'}));
+        button.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, button: 0, buttons: 1}));
+        await delay(300);
+        var option = document.querySelector(step.action_args);
+        console.log('SELECT_OPTION: option is', option);
+        if (option) {
+            option.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse'}));
+            option.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse'}));
+            option.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, button: 0, buttons: 1}));
+            console.log('SELECT_OPTION: clicked option');
+        }
+    }
 }
 
 async function placeYadaNearTarget(targetElement) {
@@ -875,13 +892,13 @@ async function play_script(data) {
 
                 if (dash_yada.target) {
                     const shouldHighlight = shouldHighlightTarget(currentStep);
-                    try {
-                        dash_yada.target.select();
-                        dash_yada.target.focus();
-                    } catch {
-                        dash_yada.target.focus();
-                    }
                     if (shouldHighlight) {
+                        try {
+                            dash_yada.target.select();
+                            dash_yada.target.focus();
+                        } catch {
+                            dash_yada.target.focus();
+                        }
                         setYadaAboveTarget(dash_yada.yada, dash_yada.target);
                         dash_yada.target.classList.add('highlighting');
                         await placeYadaNearTarget(dash_yada.target);

--- a/dash_yada/yada.js
+++ b/dash_yada/yada.js
@@ -745,6 +745,24 @@ async function runScriptAction(step, target, originalTargetSpec) {
             option.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, button: 0, buttons: 1}));
         }
     }
+    if (step.action.toLowerCase() === 'type_in_dropdown') {
+        var button = target;
+        button.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse'}));
+        button.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse'}));
+        button.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, button: 0, buttons: 1}));
+        await delay(300);
+        var search = document.querySelector('.dash-dropdown-search');
+        if (search) {
+            search.focus();
+            var text = step.action_args || '';
+            for (var i = 0; i < text.length; i++) {
+                search.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, cancelable: true, key: text[i], code: 'Key' + text[i].toUpperCase()}));
+                Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(search, text.substring(0, i + 1));
+                search.dispatchEvent(new Event('input', {bubbles: true}));
+                search.dispatchEvent(new KeyboardEvent('keyup', {bubbles: true, cancelable: true, key: text[i], code: 'Key' + text[i].toUpperCase()}));
+            }
+        }
+    }
 }
 
 async function placeYadaNearTarget(targetElement) {

--- a/dash_yada/yada.js
+++ b/dash_yada/yada.js
@@ -11,6 +11,7 @@ function escaping() {
 }
 
 function nextItem() {
+    if (dash_yada.runningAction) return;
     dash_yada.paused = false;
 }
 
@@ -1029,12 +1030,13 @@ async function play_script(data) {
                         dash_yada.previous = false;
                     }
                     if (!dash_yada.previous) {
-                        dash_yada.target.focus();
-                        await runScriptAction(
-                            currentStep,
-                            dash_yada.target,
-                            currentStep.target
-                        );
+                        dash_yada.runningAction = true;
+                        if (shouldHighlightTarget(currentStep)) {
+                            dash_yada.target.focus();
+                        }
+                        await runScriptAction(currentStep, dash_yada.target, currentStep.target);
+                        await delay(200);
+                        dash_yada.runningAction = false;
                     } else {
                         while (
                             !document.querySelector(

--- a/dash_yada/yada.js
+++ b/dash_yada/yada.js
@@ -725,20 +725,24 @@ async function runScriptAction(step, target, originalTargetSpec) {
         }
     }
     if (step.action.toLowerCase() === 'select_option') {
-        console.log('SELECT_OPTION: starting');
         var button = target;
-        console.log('SELECT_OPTION: target is', button);
         button.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse'}));
         button.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse'}));
         button.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, button: 0, buttons: 1}));
         await delay(300);
-        var option = document.querySelector(step.action_args);
-        console.log('SELECT_OPTION: option is', option);
+        var option;
+        if (step.action_args && !step.action_args.startsWith('.') && !step.action_args.startsWith('#') && !step.action_args.startsWith('[')) {
+            option = document.querySelector('.dash-options-list-option input[value="' + step.action_args + '"]');
+            if (option) {
+                option = option.closest('.dash-options-list-option');
+            }
+        } else {
+            option = document.querySelector(step.action_args);
+        }
         if (option) {
             option.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse'}));
             option.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, button: 0, buttons: 1, pointerId: 1, pointerType: 'mouse'}));
             option.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, button: 0, buttons: 1}));
-            console.log('SELECT_OPTION: clicked option');
         }
     }
 }

--- a/dash_yada/yada.js
+++ b/dash_yada/yada.js
@@ -1035,7 +1035,7 @@ async function play_script(data) {
                             dash_yada.target.focus();
                         }
                         await runScriptAction(currentStep, dash_yada.target, currentStep.target);
-                        await delay(200);
+                        await delay(500);
                         dash_yada.runningAction = false;
                     } else {
                         while (


### PR DESCRIPTION
 - The problem (dcc.Dropdown uses Radix UI which doesn't respond to synthetic MouseEvents)
 - The solution (new `select_option` action using PointerEvents, skip focus when `highlight_target` is false)